### PR TITLE
Add test for spring properties injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,17 @@
 			<scope>provided</scope>
 		</dependency>
 
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+		</dependency>
+
+		<dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+
 	</dependencies>
 
 	<dependencyManagement>

--- a/src/test/java/io.enoy.tg/TestConfiguration.java
+++ b/src/test/java/io.enoy.tg/TestConfiguration.java
@@ -1,0 +1,10 @@
+package io.enoy.tg;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.TestPropertySource;
+
+@Configuration
+@TestPropertySource(locations = "classpath:/application.yml")
+public class TestConfiguration
+{
+}

--- a/src/test/java/io.enoy.tg/TgBotSetValueTest.java
+++ b/src/test/java/io.enoy.tg/TgBotSetValueTest.java
@@ -1,0 +1,11 @@
+package io.enoy.tg;
+
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = {TestConfiguration.class})
+public class TgBotSetValueTest
+{
+}

--- a/src/test/java/io.enoy.tg/TgBotSetValueTest.java
+++ b/src/test/java/io.enoy.tg/TgBotSetValueTest.java
@@ -1,11 +1,48 @@
 package io.enoy.tg;
 
+import io.enoy.tg.bot.TgBot;
+import org.junit.Before;
+import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.junit4.SpringRunner;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assume.assumeNotNull;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = {TestConfiguration.class})
 public class TgBotSetValueTest
 {
+	@Autowired
+	private ApplicationContext context;
+	@Value("${bot.token}")
+	private String botToken;
+	@Value("${bot.name}")
+	private String botUsername;
+
+	private TgBot tgBot;
+
+	@Before
+	public void setUpTgBot()
+	{
+		assumeNotNull(context, botToken, botUsername);
+		tgBot = new TgBot(context);
+	}
+
+	@Test
+	public void shouldSetBotToken()
+	{
+		assertThat(tgBot.getBotToken(), is(botToken));
+	}
+
+	@Test
+	public void shouldSetBotUsername()
+	{
+		assertThat(tgBot.getBotUsername(), is(botUsername));
+	}
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+bot:
+  token: random-test-token
+  name: random-test-name


### PR DESCRIPTION
Because of use of `new` spring is unable to inject the properties bot.token and bot.name in class TgBot.
This fork only contains failing tests to illustrate the problem.

edit: Bean inject attributes missed that one.